### PR TITLE
fix: Compile to es2019

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "rootDir": ".",
-    "target": "ES2020",
+    "target": "ES2019",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["ES2020", "dom"],
+    "lib": ["ES2019", "dom"],
     "sourceMap": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Some older chromium browsers <80 are still pretty prevalent in tooling, so compile to es2019 to support transpilation of nullish coalescing.