### PR TITLE
Fixed nullref in useIsStrictMode when external deps provide prod-mode react when expecting dev-mode runtime

### DIFF
--- a/src/useIsStrictMode.ts
+++ b/src/useIsStrictMode.ts
@@ -34,7 +34,7 @@ export const useIsStrictMode = (): boolean => {
 
   if (isStrictMode.current === undefined) {
     let currentOwner = getCurrentOwner();
-    while (currentOwner.return) {
+    while (currentOwner && currentOwner.return) {
       currentOwner = currentOwner.return;
       if (
         currentOwner.type === REACT_STRICT_MODE_TYPE ||


### PR DESCRIPTION
This change is to address an interesting edge case we encountered, causing a nullref in useIsStrictMode, with rendering of our React components crashing.

The environment we saw this in is a bit special, but to summarize:
* Our component (consuming the fluentUI Tooltip component which in turn depends on use-disposable and useIsStrictMode), is built in a separate repository from where the component is consumed (effectively exported in an NPM package)
* Our component is built targeting React 17
* At the same time, our component NPM package specifies React and React-dom as external dependencies.
* The consuming host application is using React 18, and provides that to our consumed component
* We have a way of running dev-builds of our component as a runtime injection in the host application, without the need for re-building the host application itself

In this environment, when we attempt to run this dev-override, we hit the case where:
* Our component is running as if React was in dev-mode
* The host app however provides a prod-mode build of React

This causes the production-mode check in isStrictMode to not break as expected to return false, where it then continues down the function. It is here that it expects currentOwner to be defined, but due to this edge case it is actually undefined, leading to a nullref.

![image](https://github.com/microsoft/use-disposable/assets/11868950/184df4ce-0dc0-426f-a79d-a283a96c92bc)

The fix is simple and safe, to just be extra defensive and check for currentOwner being defined, which then defaults to the non-strict behavior