### PR TITLE
fix: error when building with module bundlers such as webpack

### DIFF
--- a/src/useIsStrictMode.ts
+++ b/src/useIsStrictMode.ts
@@ -10,7 +10,7 @@ export const getCurrentOwner = () => {
     // using react internals
     return (React as any)[
       "".concat(
-        "__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE"
+        "__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE",
       )
     ].A.getOwner();
   } catch {}

--- a/src/useIsStrictMode.ts
+++ b/src/useIsStrictMode.ts
@@ -9,8 +9,8 @@ export const getCurrentOwner = () => {
     // React 19
     // using react internals
     return (React as any)[
-      "__".concat(
-        "CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE"
+      "".concat(
+        "__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE"
       )
     ].A.getOwner();
   } catch {}
@@ -19,7 +19,7 @@ export const getCurrentOwner = () => {
     // React <18
     // using react internals
     return (React as any)[
-      "__".concat("SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED")
+      "".concat("__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED")
     ].ReactCurrentOwner.current;
   } catch {
     if (process.env.NODE_ENV !== "production") {

--- a/src/useIsStrictMode.ts
+++ b/src/useIsStrictMode.ts
@@ -4,16 +4,21 @@ import * as React from "react";
  * @returns Current react fiber being rendered
  */
 export const getCurrentOwner = () => {
+  // If you use “React” imported directly, the following code supporting different
+  // React versions will cause errors when building with the module bundler,
+  // so temporarily assign it to a variable before use.
+  const react = React;
+
   try {
     // React 19
     // @ts-ignore - using react internals
-    return React.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE.A.getOwner();
+    return react.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE.A.getOwner();
   } catch {}
 
   try {
     // React <18
     // @ts-ignore - using react internals
-    return React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
+    return react.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
       .ReactCurrentOwner.current;
   } catch {
     if (process.env.NODE_ENV !== "production") {

--- a/src/useIsStrictMode.ts
+++ b/src/useIsStrictMode.ts
@@ -4,22 +4,23 @@ import * as React from "react";
  * @returns Current react fiber being rendered
  */
 export const getCurrentOwner = () => {
-  // If you use “React” imported directly, the following code supporting different
-  // React versions will cause errors when building with the module bundler,
-  // so temporarily assign it to a variable before use.
-  const react = React;
-
+  // Note: String concatenation is used to prevent bundlers to complain with multiple versions of React
   try {
     // React 19
-    // @ts-ignore - using react internals
-    return react.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE.A.getOwner();
+    // using react internals
+    return (React as any)[
+      "__".concat(
+        "CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE"
+      )
+    ].A.getOwner();
   } catch {}
 
   try {
     // React <18
-    // @ts-ignore - using react internals
-    return react.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
-      .ReactCurrentOwner.current;
+    // using react internals
+    return (React as any)[
+      "__".concat("SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED")
+    ].ReactCurrentOwner.current;
   } catch {
     if (process.env.NODE_ENV !== "production") {
       console.error(


### PR DESCRIPTION
When using this library from the project using module bundler like webpack, current code causes build errors like in below.
While testing this library from React 19, I've found that the latest release version of this library on npm cannot be built successfully, and it is fixed on https://github.com/microsoft/use-disposable/pull/32, but still causes build errors.

## To reproduce the problem

- Set up your React project (e.g. Next.js, Remix. I used Next.js and webpack for this).
- Build this library with the latest code from the `main` branch and patch it with your package manager's patch solution like `yarn patch` or `npx patch-package`.

The build error caused by React 19 projects

```
./node_modules/use-disposable/lib/index.js
Attempted import error: '__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED' is not exported from 'react' (imported as 'React').
```

The build error caused by React 18 projects

```
./node_modules/use-disposable/lib/index.js
Attempted import error: '__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE' is not exported from 'react' (imported as 'React').
```

## The Fix

To support multiple React major versions with this single code and prevent bundlers from complaining, we need to use the same workaround as https://github.com/microsoft/fluentui/blob/23f7636c9eec05ec96691b32be169e7186b0f918/packages/react-components/react-portal/library/src/components/Portal/usePortalMountNode.ts#L13 .