### PR TITLE
fix: two failing tests for React 19 RC

### DIFF
--- a/src/useDisposable.test.ts
+++ b/src/useDisposable.test.ts
@@ -1,9 +1,7 @@
-import { describe, it, vi, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, vi, expect } from "vitest";
 import { renderHook } from "@testing-library/react";
 import * as React from "react";
 import { useDisposable } from "./useDisposable";
-
-const _maybe_it = process.env.REACT_VERSION === "rc" ? it.skip : it;
 
 describe("useDisposable", () => {
   describe("in strict mode", () => {
@@ -25,7 +23,7 @@ describe("useDisposable", () => {
       expect(dispose).toHaveBeenCalledTimes(0);
     });
 
-    _maybe_it("should call dispose on unmount", () => {
+    it("should call dispose on unmount", () => {
       const dispose = vi.fn();
       const { unmount } = renderHook(
         () => useDisposable(() => ["foo", dispose], []),
@@ -39,23 +37,20 @@ describe("useDisposable", () => {
       expect(dispose).toHaveBeenCalledTimes(1);
     });
 
-    _maybe_it(
-      "should call dispose and call factory if dependencies update",
-      () => {
-        const dispose = vi.fn();
-        const factory = vi.fn().mockReturnValue(["foo", dispose]);
-        let dep = "foo";
-        const { rerender } = renderHook(() => useDisposable(factory, [dep]), {
-          wrapper: React.StrictMode,
-        });
+    it("should call dispose and call factory if dependencies update", () => {
+      const dispose = vi.fn();
+      const factory = vi.fn().mockReturnValue(["foo", dispose]);
+      let dep = "foo";
+      const { rerender } = renderHook(() => useDisposable(factory, [dep]), {
+        wrapper: React.StrictMode,
+      });
 
-        dep = "bar";
-        rerender();
+      dep = "bar";
+      rerender();
 
-        expect(dispose).toHaveBeenCalledTimes(1);
-        expect(factory).toHaveBeenCalledTimes(2);
-      },
-    );
+      expect(dispose).toHaveBeenCalledTimes(1);
+      expect(factory).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe("not strict mode", () => {

--- a/src/useStrictMemo.ts
+++ b/src/useStrictMemo.ts
@@ -9,13 +9,17 @@ export function useStrictMemo<TMemoized>(
   factory: () => any,
   deps: React.DependencyList | undefined,
 ): TMemoized | null {
+  const factoryResultRef = React.useRef(null);
+
   return React.useMemo(() => {
     const currentOwner = getCurrentOwner();
     if (!memoSet.has(currentOwner)) {
       memoSet.add(currentOwner);
-      return null;
+      const factoryResult = factory();
+      factoryResultRef.current = factoryResult;
+      return factoryResult;
     }
 
-    return factory();
+    return factoryResultRef.current;
   }, deps);
 }

--- a/src/useStrictMemo.ts
+++ b/src/useStrictMemo.ts
@@ -10,16 +10,23 @@ export function useStrictMemo<TMemoized>(
   deps: React.DependencyList | undefined,
 ): TMemoized | null {
   const factoryResultRef = React.useRef(null);
+  const reactMajorVersion = React.useMemo(() => {
+    return Number(React.version.split(".")[0]);
+  }, [React.version]);
 
   return React.useMemo(() => {
     const currentOwner = getCurrentOwner();
     if (!memoSet.has(currentOwner)) {
       memoSet.add(currentOwner);
-      const factoryResult = factory();
-      factoryResultRef.current = factoryResult;
-      return factoryResult;
+
+      if (reactMajorVersion < 19) {
+        return null;
+      }
+
+      factoryResultRef.current = factory();
+      return factoryResultRef.current;
     }
 
-    return factoryResultRef.current;
+    return reactMajorVersion < 19 ? factory() : factoryResultRef.current;
   }, deps);
 }


### PR DESCRIPTION
During testing with React 19 RC, I discovered that several tests for this library were failing. 

This pull request addresses these failures by modifying the `useStrictMemo` hook to align with the `React.StrictMode` behavior of `useMemo` in React 19 RC. 

To maintain compatibility with earlier React versions, I've included some minor workarounds.

---

React 19 RC changes: https://react.dev/blog/2024/04/25/react-19-upgrade-guide#strict-mode-improvements